### PR TITLE
pin-node-port-to-healh-check-port

### DIFF
--- a/fleet-default/ingress-nginx/ingress-nginx-values.yaml
+++ b/fleet-default/ingress-nginx/ingress-nginx-values.yaml
@@ -24,12 +24,15 @@ controller:
     # real-ip-header: "proxy_protocol"
   service:
     type: LoadBalancer
+    nodePorts:
+      http: 31076
+      https: 32587
     annotations:
       ingressclass.kubernetes.io/is-default-class: "true"
       service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
       service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
       service.beta.kubernetes.io/aws-load-balancer-healthcheck-path: /healthz
-      service.beta.kubernetes.io/aws-load-balancer-healthcheck-port: 10254
+      service.beta.kubernetes.io/aws-load-balancer-healthcheck-port: "32587"
       service.beta.kubernetes.io/aws-load-balancer-healthcheck-protocol: http
       service.beta.kubernetes.io/aws-load-balancer-ip-address-type: ipv4
       service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: instance


### PR DESCRIPTION
Pin nodeport to the healthcheck port

# Story
As we saw in today’s outage on Glass Canvas, the root cause was a mismatch between the AWS Load Balancer's health check port and the actual port exposed on the EC2 nodes. This happened because the NGINX ingress controller's NodePort wasn’t explicitly defined in the Helm values.yaml, so Kubernetes assigned a random one during deployment.

Even though the service type is LoadBalancer, because we're using an AWS NLB with target-type: instance, AWS expects to send health checks directly to the EC2 node IP and NodePort. If the NodePort changes (which it can, if not pinned), the health check fails — causing all targets to be marked unhealthy, just like we saw earlier.

To prevent this, we’re updating the Helm config to explicitly define the NodePort values for HTTP and HTTPS. This ensures:
- The correct port is always used on every deployment
- AWS target groups stay in sync with Kubernetes
- No manual updates to the Load Balancer or health check config are needed
- We avoid repeat outages due to port drift
- This will make our setup more stable and predictable across all environments.